### PR TITLE
docs: reference DAS skills via CLI; drop ai-dev-kit link

### DIFF
--- a/.cursor/rules/coding-standards.md
+++ b/.cursor/rules/coding-standards.md
@@ -12,7 +12,7 @@
 
 - Always build SDP (Spark Declarative Pipelines) using **SQL, not Python**. All tables must be defined as `CREATE OR REFRESH MATERIALIZED VIEW` or `CREATE OR REFRESH STREAMING TABLE` in `.sql` files.
 - Use `dbldatagen` (Databricks Labs Data Generator) for synthetic data generation. Prefer it over hand-rolling random data with pandas/Faker for Spark-scale data.
-- For Databricks-specific patterns and best practices, refer to the [Databricks AI Dev Kit](https://github.com/databricks-solutions/ai-dev-kit).
+- For Databricks-specific patterns and best practices, see [`databricks/databricks-agent-skills`](https://github.com/databricks/databricks-agent-skills). Install with `databricks aitools install`.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,27 @@ This repo provides example skills, instructions, and tooling organized by domain
 
 ---
 
+## Companion Skills (databricks-agent-skills)
+
+The skills in this repo are the **enterprise governance overlay** — naming conventions, audit columns, TBLPROPERTIES requirements, PII policies. For the **generic Databricks knowledge** that sits underneath (CLI usage, Lakeflow Jobs syntax, SDP semantics, Asset Bundles, Lakebase, Model Serving, …), use [`databricks/databricks-agent-skills`](https://github.com/databricks/databricks-agent-skills) ("DAS"). It is the canonical source and ships a CLI installer:
+
+```bash
+databricks aitools install                       # all stable DAS skills
+databricks aitools install databricks-pipelines  # just the SDP skill
+databricks aitools install databricks-jobs       # just the Lakeflow Jobs skill
+```
+
+The two compose: DAS teaches *how Databricks works*, and the skills in this repo encode *how this enterprise wants it written*. The most relevant DAS skills for a Genie Code + SDP workflow are:
+
+- `databricks-core` — CLI, auth, profile selection (parent skill)
+- `databricks-pipelines` — Lakeflow Spark Declarative Pipelines (formerly DLT)
+- `databricks-jobs` — Lakeflow Jobs orchestration
+- `databricks-dabs` — Declarative Automation Bundles (formerly Asset Bundles)
+
+DAS install is optional for running the demo; the stages in [`docs/DEMO_SCRIPT.md`](docs/DEMO_SCRIPT.md) work without it.
+
+---
+
 ## How It Works
 
 This demo shows three stages of Genie Code customization:


### PR DESCRIPTION
## Summary

Replaces the previous attempt (185-line redistillation of the upstream `databricks-agent-skills` `databricks-jobs` skill) with the right framing: this repo holds the **enterprise governance overlay**, [DAS](https://github.com/databricks/databricks-agent-skills) holds the **generic Databricks knowledge**, and the two compose.

Two file changes:

- **`README.md`** — new "Companion Skills (databricks-agent-skills)" section explaining the split and the one-command CLI install (`databricks aitools install`). Lists the DAS skills most relevant to a Genie Code + SDP workflow: `databricks-core`, `databricks-pipelines`, `databricks-jobs`, `databricks-dabs`.
- **`.cursor/rules/coding-standards.md`** — swaps the `ai-dev-kit` link for the canonical `databricks/databricks-agent-skills` link.

## Why not duplicate the DAS skill into this repo?

The previous draft of this PR distilled DAS's 2,878-line `databricks-jobs` skill into a 185-line copy in `skills/data_eng/`. That created drift (the demo copy goes stale the moment DAS updates) and added no enterprise-specific governance content — it just paraphrased upstream. Referencing DAS via the CLI installer keeps a single source of truth.

## What this repo keeps

The existing skills (`sdp-basics`, `table-governance`, `pii-management`, `sentiment-analysis`) stay — they encode enterprise-specific rules (snake_case + layer prefix, mandatory audit columns, TBLPROPERTIES requirements, PII handling) that don't belong in DAS.

## Demo impact

None. The Stages 1–5 walkthrough in `docs/DEMO_SCRIPT.md` works unchanged. DAS install is optional and additive — useful for users running Genie Code outside the narrow SDP demo path.

## Test plan

- [ ] README renders cleanly with the new "Companion Skills" section.
- [ ] `grep -ri "ai-dev-kit\|a-d-k\|aidevkit" .` returns nothing.
- [ ] Stage 1–5 walkthrough in `docs/DEMO_SCRIPT.md` still runs end-to-end.

This pull request and its description were written by Isaac.