### PR TITLE
docs: replace ai-dev-kit link with databricks-agent-skills

### DIFF
--- a/.cursor/rules/coding-standards.md
+++ b/.cursor/rules/coding-standards.md
@@ -12,7 +12,7 @@
 
 - Always build SDP (Spark Declarative Pipelines) using **SQL, not Python**. All tables must be defined as `CREATE OR REFRESH MATERIALIZED VIEW` or `CREATE OR REFRESH STREAMING TABLE` in `.sql` files.
 - Use `dbldatagen` (Databricks Labs Data Generator) for synthetic data generation. Prefer it over hand-rolling random data with pandas/Faker for Spark-scale data.
-- For Databricks-specific patterns and best practices, refer to the [Databricks AI Dev Kit](https://github.com/databricks-solutions/ai-dev-kit).
+- For Databricks-specific patterns and best practices, see [`databricks/databricks-agent-skills`](https://github.com/databricks/databricks-agent-skills). Install with `databricks aitools install`.
 
 ## Documentation
 


### PR DESCRIPTION
## Summary

One-line swap in \`.cursor/rules/coding-standards.md\`: the \"Databricks-specific patterns\" pointer now goes to [\`databricks/databricks-agent-skills\`](https://github.com/databricks/databricks-agent-skills) (the canonical home) instead of \`databricks-solutions/ai-dev-kit\`. Also mentions the one-command CLI install (\`databricks aitools install\`).

Replaces #4, which tried to redistil a DAS skill into this repo — wrong direction, since DAS is already the canonical source and ships its own installer.

## Test plan

- [ ] \`grep -ri \"ai-dev-kit\" .\` returns nothing.

This pull request and its description were written by Isaac.