### PR TITLE
Clarify GitHub MCP token needs no scopes for public repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ Once installed, Genie Code picks them up automatically. You can also invoke them
 
 Connect Genie Code to a GitHub MCP server to fetch the same skills dynamically -- no need to copy files into the workspace manually. The MCP connection points directly to the `skills/data_eng/` folder in this repo (or your fork of it).
 
+> **About the GitHub token:** the GitHub-hosted MCP server requires a token to authenticate, but because this repo is **public** the token needs **no scopes**. A classic PAT with **no scopes selected**, or a fine-grained PAT with **read-only `Contents` access to the public repo**, is sufficient. Do not grant `repo`, `read:org`, or other privileged scopes.
+
 **a. Configure**
 
 ```bash

--- a/local_deployment/README.md
+++ b/local_deployment/README.md
@@ -154,9 +154,9 @@ Re-runs are safe: the Marketplace install is skipped if the scratch catalog alre
 
 ### MCP Connection
 
-The MCP connection **must** be created via SQL Editor (not API/CLI/DAB). The `secret()` function only resolves correctly in SQL context.
+The MCP connection must be created in a **SQL context** so that the `secret()` function resolves -- the SQL Editor works, and so does the SQL Statement Execution API (run against a SQL warehouse). Plain REST/CLI catalog APIs and DAB do **not** resolve `secret()`, so use one of the SQL paths below.
 
-1. Store your GitHub PAT in a secret scope:
+1. Store your GitHub PAT in a secret scope. Because this repo is **public**, the token needs **no scopes** -- a classic PAT with no scopes selected, or a fine-grained PAT with read-only `Contents` access to the public repo, is enough (do not grant `repo` / `read:org`):
 
 ```bash
 databricks secrets create-scope <your-scope> --profile <your-cli-profile>

--- a/mcp/deploy_mcp.py
+++ b/mcp/deploy_mcp.py
@@ -73,7 +73,15 @@ def setup_secret_scope(w: WorkspaceClient, config: dict) -> None:
     except ResourceAlreadyExists:
         print(f"Secret scope already exists: {scope}")
 
-    pat = getpass.getpass("Enter your GitHub PAT: ")
+    # The repo is public, so the GitHub MCP server only needs a token to
+    # authenticate the caller -- it does NOT need any scopes. A classic PAT with
+    # no scopes selected (or a fine-grained PAT with read-only Contents access to
+    # the public repo) is sufficient. Do not grant repo / read:org / etc.
+    print(
+        "\nNOTE: This repo is public, so a no-scope (or minimal read-only) "
+        "GitHub PAT is sufficient. Do not grant privileged scopes."
+    )
+    pat = getpass.getpass("Enter your GitHub PAT (no scopes required): ")
     if not pat.strip():
         print("ERROR: PAT cannot be empty.")
         sys.exit(1)
@@ -90,9 +98,9 @@ def print_connection_sql(config: dict) -> None:
     repo = config["github_repo"]
 
     create_sql = f"""\
--- Run this in a Databricks SQL Editor to create the MCP connection.
--- The secret() function only resolves correctly in SQL Editor context.
--- Do NOT create this connection via API, CLI, or DAB.
+-- Run this in a SQL context so that secret() resolves: the Databricks SQL
+-- Editor, or the SQL Statement Execution API against a SQL warehouse.
+-- Plain REST/CLI catalog APIs and DAB do NOT resolve secret().
 -- Requires CREATE CONNECTION privilege on the metastore.
 
 CREATE CONNECTION IF NOT EXISTS `{conn_name}`


### PR DESCRIPTION
## Summary

- The GitHub-hosted MCP server (`api.githubcopilot.com/mcp`) requires a token to authenticate, but because this repo is **public** the token needs **no scopes**. Updated `README.md`, `local_deployment/README.md`, and `mcp/deploy_mcp.py` to recommend a no-scope / minimal read-only PAT and explicitly say not to grant `repo` / `read:org`.
- Corrected the "**must** be created via SQL Editor" guidance: the **SQL Statement Execution API** (run against a SQL warehouse) is also a valid SQL context where `secret()` resolves. Only plain REST/CLI catalog APIs and DAB do not.

### Why

Verified empirically: the MCP endpoint returns 401 with no token and with a bogus token, so the token can't be removed -- but a no-scope token authenticates and reads the public repo fine (HTTP 200 against both the GitHub API and the MCP `initialize` call). The connection was also created successfully via the Statement Execution API, confirming the SQL-Editor-only claim was too strict.

## Test plan

- [ ] `python mcp/deploy_mcp.py` prompts now state a no-scope PAT is sufficient
- [ ] Create the MCP connection with a no-scope PAT and confirm skills fetch works
- [ ] Docs render correctly on GitHub